### PR TITLE
Enable building image on Debian

### DIFF
--- a/1_compile.sh
+++ b/1_compile.sh
@@ -54,7 +54,9 @@ patch_config() {
     ./scripts/config --file "../${DIR}-build/.config" "$_OP" "$key"
 }
 
-for DEP in riscv64-linux-gnu-gcc swig cpio; do
+DEP_LIST="DEP_LIST_$ID"
+eval DEP_LIST=\$$DEP_LIST
+for DEP in $DEP_LIST; do
     check_deps ${DEP}
 done
 

--- a/2_create_sd.sh
+++ b/2_create_sd.sh
@@ -5,6 +5,10 @@ set -e
 
 . ./consts.sh
 
+# Dependency list
+DEP_LIST_arch="arch-install-scripts qemu-user-static qemu-user-static-binfmt"
+DEP_LIST_debian="arch-install-scripts qemu-user-static"
+
 check_root_fs() {
     if [ ! -f "${ROOT_FS}" ]; then
         wget "${ROOT_FS_DL}"
@@ -44,7 +48,9 @@ DEVICE=${1}
 
 if [ "${USE_CHROOT}" != 0 ]; then
     # check_deps for arch-chroot on non RISC-V host
-    for DEP in arch-install-scripts qemu-user-static qemu-user-static-binfmt; do
+    DEP_LIST="DEP_LIST_$ID"
+    eval DEP_LIST=\$$DEP_LIST
+    for DEP in $DEP_LIST; do
         check_deps ${DEP}
     done
 fi

--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ There are multiple sources for an Archlinux image:
 - WiFi driver (rtl8723ds) based on https://github.com/lwfinger/rtl8723ds
 - RootFS based on https://archriscv.felixc.at (root password is ~~`sifive`~~ `archriscv`)
 
-## How to build
+## How to build on ArchLinux
 1. Install requirements: `pacman -Sy riscv64-linux-gnu-gcc swig cpio python3 python-setuptools base-devel bc`
    1. If you want to `chroot` into the RISC-V image, you also need `arch-install-scripts qemu-user-static qemu-user-static-binfmt`
+1. Edit `consts.sh` to your needs. For example, you may want to select a [different DTB](https://github.com/sehraf/riscv-arch-image-builder/blob/5c450da98d578617781ae13f9d2b0850a61b21c4/consts.sh#L22) for a different board variant.
+1. Run `1_compile.sh` which compiles everything into the `output` folder.
+1. Run `2_create_sd.sh /dev/<device>` to flash everything on the SD card.
+1. Configure your Archlinux :rocket:
+
+## How to build on Debian
+1. Install requirements: `apt install -y gcc-riscv64-linux-gnu bison flex python3-dev libssl-dev swig cpio python3-setuptools build-essential bc`
+   1. If you want to `chroot` into the RISC-V image, you also need `arch-install-scripts qemu-user-static`
 1. Edit `consts.sh` to your needs. For example, you may want to select a [different DTB](https://github.com/sehraf/riscv-arch-image-builder/blob/5c450da98d578617781ae13f9d2b0850a61b21c4/consts.sh#L22) for a different board variant.
 1. Run `1_compile.sh` which compiles everything into the `output` folder.
 1. Run `2_create_sd.sh /dev/<device>` to flash everything on the SD card.

--- a/consts.sh
+++ b/consts.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/sh
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+fi
+
+# Dependency list
+DEP_LIST_arch="riscv64-linux-gnu-gcc swig cpio"
+DEP_LIST_debian="gcc-riscv64-linux-gnu bison flex python3-dev libssl-dev"
+
 export CROSS_COMPILE='riscv64-linux-gnu-'
 export ARCH='riscv'
 PWD="$(pwd)"
@@ -58,10 +67,24 @@ export IGNORE_COMMITS=0
 export DEBUG='n'
 
 check_deps() {
-    if ! pacman -Qi "${1}" >/dev/null; then
-        echo "Please install '${1}'"
+    case $ID in
+    arch)
+        if ! pacman -Qi "${1}" >/dev/null; then
+            echo "Please install '${1}'"
+            exit 1
+        fi
+    ;;
+    debian)
+        if ! dpkg -l "${1}" >/dev/null; then
+            echo "Please install '${1}'"
+            exit 1
+        fi
+    ;;
+    *)
+        echo "This script is running on not supported distro!"
         exit 1
-    fi
+    ;;
+    esac
 }
 
 if [ -n "${CI_BUILD}" ]; then


### PR DESCRIPTION
Enable building image on Debian, since all the tools used for building image can be installed on Debian and chroot also work.

Tools dependency list has been separated and `check_deps()` will check this script is running on Arch or Debian, more host-distro can be supported in the future.